### PR TITLE
Dynamic Field Hints

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -135,13 +135,14 @@ class CrudController extends Controller
         if (is_countable($columns)) {
             $fields     = $this->crud->fields();
             foreach ($fields as $key => $field) {
-                $comment = null;
-                foreach ($columns as $column) {
-                    if($column->Field === $field['name']){
-                        if ($comment = $column->Comment ? trim($column->Comment) : null) {
-                            $this->crud->modifyField($field['name'], ['hint' => $comment]);
+                if (!isset($field['hint']) && isset($field['name'])) {
+                    foreach ($columns as $column) {
+                        if($column->Field === $field['name']){
+                            if ($comment = $column->Comment ? trim($column->Comment) : null) {
+                                $this->crud->modifyField($field['name'], ['hint' => $comment]);
+                            }
+                            break;
                         }
-                        break;
                     }
                 }
             }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -210,3 +210,17 @@ if (! function_exists('is_countable')) {
         return is_array($obj) || $obj instanceof Countable;
     }
 }
+
+if (! function_exists('backpack_get_column_info')) {
+    /**
+     * Get an array of info for the columns of the given connection and table
+     *
+     * @param string $connection The name of the DB connection
+     * @param string $table      The name of the DB table
+     * @return array
+     */
+    function backpack_get_column_info($connection, $table)
+    {
+        return DB::connection($connection)->select(DB::raw('SHOW FULL COLUMNS FROM '.$table.';'));
+    }
+}


### PR DESCRIPTION
This change, if accepted, would add the ability to dynamically set the 'hint' value for each currently configured CRUD field by pulling the "comment" for the column in the database if it exists. 

## Notes:
- hints are only set if the method is called
- hints are only set if the column in the db has a Comment 
- hints are not set if a hint already exists on the field
- hints are not set if "hint" on the field is set to an empty string

## Example usage: 


```

public function setupCreateOperation()
  {
      $this->crud->setValidation(TagCrudRequest::class);

      $this->crud->addField([
        'name' => 'name',
        'type' => 'text',
        'label' => "Tag name"
      ]);
      $this->crud->addField([
        'name' => 'slug',
        'type' => 'text',
        'label' => "URL Segment (slug)"
      ]);
     $this->setFieldHintsFromColumnComments(); // Field hints have now been set to their column's "comments" if they exist in the db

  }
```